### PR TITLE
fix the formatting for list of OBO ontologies imported

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,19 +55,20 @@ Below are the top-level classes in MAxO and examples of each class.
 
 
 ## OBO ontologies imported
+
 Below are the imported ontologies used for logical definitions
 
-        - [NBO ](https://github.com/obo-behavior/behavior-ontology)
-        - [FOODON](https://github.com/FoodOntology/foodon)
-        - [CHEBI](https://github.com/ebi-chebi/ChEBI)
-        - [MAXO](https://github.com/monarch-initiative/MAxO)
-        - [HP](https://github.com/obophenotype/human-phenotype-ontology/issues)
-        - [UBERON](https://github.com/obophenotype/uberon)
-        - PR
-        - RO
-        - IAO
-        - [GO](https://github.com/geneontology/)
-        - [OBI](https://github.com/obi-ontology/obi)
+- [NBO](https://github.com/obo-behavior/behavior-ontology)
+- [FOODON](https://github.com/FoodOntology/foodon)
+- [CHEBI](https://github.com/ebi-chebi/ChEBI)
+- [MAXO](https://github.com/monarch-initiative/MAxO)
+- [HP](https://github.com/obophenotype/human-phenotype-ontology/issues)
+- [UBERON](https://github.com/obophenotype/uberon)
+- PR
+- RO
+- IAO
+- [GO](https://github.com/geneontology/)
+- [OBI](https://github.com/obi-ontology/obi)
         
         
 ### MAxO Curation


### PR DESCRIPTION
- added a line below the header
- justified the bullet points on the left, that seemed to be affecting the links (not sure why!)

@LCCarmody you can preview the changes by going to Files changed and click the three dots on the right, then View File

<img width="234" alt="image" src="https://user-images.githubusercontent.com/6722114/196472715-de0f2165-ad29-4e55-b799-a1ee2861245a.png">
