### PR TITLE
Fix pharmacotherapy hierachy

### DIFF
--- a/src/ontology/maxo-edit.owl
+++ b/src/ontology/maxo-edit.owl
@@ -1367,7 +1367,6 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/MAXO_0000058> "pharmaceutical treatment")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/MAXO_0000058> "pharmacological treatment")
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "http://orcid.org/0000-0001-7941-2961") rdfs:comment <http://purl.obolibrary.org/obo/MAXO_0000058> "Medical treatment by means of drugs.")
-SubClassOf(<http://purl.obolibrary.org/obo/MAXO_0000058> <http://purl.obolibrary.org/obo/MAXO_0000002>)
 
 # Class: <http://purl.obolibrary.org/obo/MAXO_0000061> (antibacterial agent therapy)
 
@@ -5954,8 +5953,20 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynony
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/MAXO_0000594> "clinical quantitative reverse transcription PCR testing"@en)
 SubClassOf(<http://purl.obolibrary.org/obo/MAXO_0000594> <http://purl.obolibrary.org/obo/MAXO_0000589>)
 
-# Class: <http://purl.obolibrary.org/obo/MAXO_0000595> (<http://purl.obolibrary.org/obo/MAXO_0000595>)
+# Class: <http://purl.obolibrary.org/obo/MAXO_0000595> (radiograph imaging procedure)
 
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/MAXO_0000595> "A procedure producing an image on a radiosensitive surface by x-ray radiation that has penetrated and passed through a structure in order to diagnose or treat a patient.")
+AnnotationAssertion(dce:date <http://purl.obolibrary.org/obo/MAXO_0000595> "2020-04-07T15:49:43Z")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#created_by> <http://purl.obolibrary.org/obo/MAXO_0000595> "http://orcid.org/0000-0001-7941-2961")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> <http://purl.obolibrary.org/obo/MAXO_0000595> "NCIT:C38101")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> <http://purl.obolibrary.org/obo/MAXO_0000595> "NCIT:C60727")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/MAXO_0000595> "X-ray imaging procedure")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/MAXO_0000595> "radiogram imaging procedure")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/MAXO_0000595> "radiographic imaging procedure")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/MAXO_0000595> "radiographic procedure")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/MAXO_0000595> "radiography")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/MAXO_0000595> "radiography imaging procedure")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/MAXO_0000595> "radiograph imaging procedure")
 SubClassOf(<http://purl.obolibrary.org/obo/MAXO_0000595> <http://purl.obolibrary.org/obo/MAXO_0000005>)
 
 # Class: <http://purl.obolibrary.org/obo/MAXO_0000596> (infectious disease screening)
@@ -9904,6 +9915,10 @@ SubClassOf(<http://purl.obolibrary.org/obo/MAXO_0001257> <http://purl.obolibrary
 # Class: <http://purl.obolibrary.org/obo/MAXO_0001258> (vitamin A supplementation)
 
 SubClassOf(<http://purl.obolibrary.org/obo/MAXO_0001258> <http://purl.obolibrary.org/obo/MAXO_0001135>)
+
+# Class: <http://purl.obolibrary.org/obo/MAXO_0001269> (clinical biopsy)
+
+SubClassOf(<http://purl.obolibrary.org/obo/MAXO_0001269> <http://purl.obolibrary.org/obo/MAXO_0000003>)
 
 # Class: <http://purl.obolibrary.org/obo/MAXO_0009003> (preimplantation genetic testing)
 

--- a/src/ontology/maxo-edit.owl
+++ b/src/ontology/maxo-edit.owl
@@ -1367,6 +1367,8 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/MAXO_0000058> "pharmaceutical treatment")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/MAXO_0000058> "pharmacological treatment")
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "http://orcid.org/0000-0001-7941-2961") rdfs:comment <http://purl.obolibrary.org/obo/MAXO_0000058> "Medical treatment by means of drugs.")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/MAXO_0000058> "pharmacotherapy")
+EquivalentClasses(<http://purl.obolibrary.org/obo/MAXO_0000058> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/MAXO_0000002> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/MAXO_0000864> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/CHEBI_24431> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000087> <http://purl.obolibrary.org/obo/CHEBI_23888>)))))
 
 # Class: <http://purl.obolibrary.org/obo/MAXO_0000061> (antibacterial agent therapy)
 
@@ -2102,7 +2104,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/MAXO_0000157> "antiparkisonian drug treatment")
 SubClassOf(<http://purl.obolibrary.org/obo/MAXO_0000157> <http://purl.obolibrary.org/obo/MAXO_0000260>)
 
-# Class: <http://purl.obolibrary.org/obo/MAXO_0000158> (antiparasititic agent therapy)
+# Class: <http://purl.obolibrary.org/obo/MAXO_0000158> (antiparasitic agent therapy)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/MAXO_0000158> "Use of a substance used to treat or prevent parasitic infections.")
 AnnotationAssertion(dce:date <http://purl.obolibrary.org/obo/MAXO_0000158> "2019-01-22T17:53:06Z"^^xsd:dateTime)
@@ -2335,7 +2337,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/MAXO_0000173> "medication for nausea treatment")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/MAXO_0000173> "medication for treatment of nausea")
 
-# Class: <http://purl.obolibrary.org/obo/MAXO_0000174> (anti-fungal agent therapy)
+# Class: <http://purl.obolibrary.org/obo/MAXO_0000174> (antifungal agent therapy)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/MAXO_0000174> "Use of a drug to prevent or treat fungal infections in humans or animals.")
 AnnotationAssertion(dce:date <http://purl.obolibrary.org/obo/MAXO_0000174> "2019-01-22T18:02:00Z"^^xsd:dateTime)
@@ -2641,7 +2643,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynony
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/MAXO_0000191> "vasodilator agent therapy"@en)
 SubClassOf(<http://purl.obolibrary.org/obo/MAXO_0000191> <http://purl.obolibrary.org/obo/MAXO_0000181>)
 
-# Class: <http://purl.obolibrary.org/obo/MAXO_0000193> (non-opioid analgesic therapy)
+# Class: <http://purl.obolibrary.org/obo/MAXO_0000193> (non-opioid analgesics agent therapy)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/MAXO_0000193> "Use of a drug that has principally analgesic, antipyretic and anti-inflammatory actions. Non-narcotic analgesics do not bind to opioid receptors.")
 AnnotationAssertion(dce:date <http://purl.obolibrary.org/obo/MAXO_0000193> "2019-01-22T18:22:25Z"^^xsd:dateTime)
@@ -2659,7 +2661,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynony
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/MAXO_0000193> "non-opioid analgesics agent therapy"@en)
 SubClassOf(<http://purl.obolibrary.org/obo/MAXO_0000193> <http://purl.obolibrary.org/obo/MAXO_0000159>)
 
-# Class: <http://purl.obolibrary.org/obo/MAXO_0000194> (opioid analgesic therapy)
+# Class: <http://purl.obolibrary.org/obo/MAXO_0000194> (opioid analgesics agent therapy)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/MAXO_0000194> "Use of a narcotic or opioid substance, synthetic or semisynthetic agent producing profound analgesia, drowsiness, and changes in mood.")
 AnnotationAssertion(dce:date <http://purl.obolibrary.org/obo/MAXO_0000194> "2019-01-22T18:22:42Z"^^xsd:dateTime)
@@ -2677,7 +2679,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynony
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/MAXO_0000194> "opioid analgesics agent therapy"@en)
 SubClassOf(<http://purl.obolibrary.org/obo/MAXO_0000194> <http://purl.obolibrary.org/obo/MAXO_0000159>)
 
-# Class: <http://purl.obolibrary.org/obo/MAXO_0000195> (local anesthesia treatment)
+# Class: <http://purl.obolibrary.org/obo/MAXO_0000195> (local anesthetic agent therapy)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/MAXO_0000195> "Treatment with any member of a group of drugs that reversibly inhibit the propagation of signals along nerves. Wide variations in potency, stability, toxicity, water-solubility and duration of action determine the route used for administration, e.g. topical, intravenous, epidural or spinal block.")
 AnnotationAssertion(dce:date <http://purl.obolibrary.org/obo/MAXO_0000195> "2019-01-22T18:24:45Z"^^xsd:dateTime)
@@ -3001,7 +3003,7 @@ SubClassOf(<http://purl.obolibrary.org/obo/MAXO_0000220> <http://purl.obolibrary
 SubClassOf(<http://purl.obolibrary.org/obo/MAXO_0000220> <http://purl.obolibrary.org/obo/MAXO_0000634>)
 SubClassOf(<http://purl.obolibrary.org/obo/MAXO_0000220> <http://purl.obolibrary.org/obo/MAXO_0000640>)
 
-# Class: <http://purl.obolibrary.org/obo/MAXO_0000221> (NSAID therapy)
+# Class: <http://purl.obolibrary.org/obo/MAXO_0000221> (nonsteroidal anti-inflammatory agent therapy)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/MAXO_0000221> "Treatment with an anti-inflammatory drug that is not a steroid. In addition to anti-inflammatory actions, non-steroidal anti-inflammatory drugs have analgesic, antipyretic, and platelet-inhibitory actions. They act by blocking the synthesis of prostaglandins by inhibiting cyclooxygenase, which converts arachidonic acid to cyclic endoperoxides, precursors of prostaglandins.")
 AnnotationAssertion(dce:date <http://purl.obolibrary.org/obo/MAXO_0000221> "2019-01-22T18:44:26Z"^^xsd:dateTime)
@@ -3442,7 +3444,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynony
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/MAXO_0000247> "antiherpetic agent therapy"@en)
 SubClassOf(<http://purl.obolibrary.org/obo/MAXO_0000247> <http://purl.obolibrary.org/obo/MAXO_0000168>)
 
-# Class: <http://purl.obolibrary.org/obo/MAXO_0000248> (anti-HIV agent therapy)
+# Class: <http://purl.obolibrary.org/obo/MAXO_0000248> (anti-human immunodeficiency virus agent therapy)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/MAXO_0000248> "Treatment with an antiviral agent that destroys or inhibits the replication of the human immunodeficiency virus.")
 AnnotationAssertion(dce:date <http://purl.obolibrary.org/obo/MAXO_0000248> "2019-01-22T20:16:07Z"^^xsd:dateTime)
@@ -3459,7 +3461,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynony
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/MAXO_0000248> "anti-human immunodeficiency virus agent therapy"@en)
 SubClassOf(<http://purl.obolibrary.org/obo/MAXO_0000248> <http://purl.obolibrary.org/obo/MAXO_0000168>)
 
-# Class: <http://purl.obolibrary.org/obo/MAXO_0000249> (anti-HIV therapy, fusion inhibitor)
+# Class: <http://purl.obolibrary.org/obo/MAXO_0000249> (HIV fusion inhibitor therapy)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/MAXO_0000249> "Treatment with a drug which interferes with the binding, fusion and entry of an HIV virion to a human cell. By blocking this step in HIV's replication cycle, such agents slow the progression from HIV infection to AIDS.")
 AnnotationAssertion(dce:date <http://purl.obolibrary.org/obo/MAXO_0000249> "2019-01-22T20:18:25Z"^^xsd:dateTime)
@@ -4492,7 +4494,7 @@ AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/MAXO_0000443> "er
 SubClassOf(<http://purl.obolibrary.org/obo/MAXO_0000443> <http://purl.obolibrary.org/obo/MAXO_0000015>)
 SubClassOf(<http://purl.obolibrary.org/obo/MAXO_0000443> <http://purl.obolibrary.org/obo/MAXO_0000442>)
 
-# Class: <http://purl.obolibrary.org/obo/MAXO_0000444> (erythropoietin inhibitor therapy)
+# Class: <http://purl.obolibrary.org/obo/MAXO_0000444> (erythropoietin inhibitor agent therapy)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/MAXO_0000444> "Use of a drug that inhibits erythropoietin, a glycoprotein hormone that controls erythropoiesis (red blood cell production).")
 AnnotationAssertion(dce:date <http://purl.obolibrary.org/obo/MAXO_0000444> "2019-10-08T18:49:31Z"^^xsd:dateTime)
@@ -6278,7 +6280,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynony
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/MAXO_0000625> "inhalation anesthetic therapy"@en)
 SubClassOf(<http://purl.obolibrary.org/obo/MAXO_0000625> <http://purl.obolibrary.org/obo/MAXO_0001020>)
 
-# Class: <http://purl.obolibrary.org/obo/MAXO_0000626> (intravenous anesthetic therapy)
+# Class: <http://purl.obolibrary.org/obo/MAXO_0000626> (intravenous anesthetic agent therapy)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/MAXO_0000626> "A therapy utilizing an intravenous substance that produces loss of consciousness.")
 AnnotationAssertion(dce:date <http://purl.obolibrary.org/obo/MAXO_0000626> "2020-05-26T18:19:32Z"^^xsd:dateTime)
@@ -6296,7 +6298,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynony
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/MAXO_0000626> "intravenous anesthetic agent therapy"@en)
 SubClassOf(<http://purl.obolibrary.org/obo/MAXO_0000626> <http://purl.obolibrary.org/obo/MAXO_0001020>)
 
-# Class: <http://purl.obolibrary.org/obo/MAXO_0000627> (topical anesthetic therapy)
+# Class: <http://purl.obolibrary.org/obo/MAXO_0000627> (topical anesthetic agent therapy)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "PMID:26702198") <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/MAXO_0000627> "A superficial loss of sensation in conjunctiva, mucous membranes, or skin, produced by direct application of local anesthetic solutions, ointments, gels or sprays.")
 AnnotationAssertion(dce:date <http://purl.obolibrary.org/obo/MAXO_0000627> "2020-05-26T18:25:03Z"^^xsd:dateTime)

--- a/src/patterns/data/manual/pharmacotherapy_chemicalrole.tsv
+++ b/src/patterns/data/manual/pharmacotherapy_chemicalrole.tsv
@@ -1,5 +1,4 @@
 defined_class	defined_class_name	chemical_entity	chemical_entity_label	drug_role	drug_role_entity	created_by	date	comment	xref	syns
-MAXO:0000058	pharmacotherapy	CHEBI:24431	chemical entity	CHEBI:23888	drug					
 MAXO:0000061	antibacterial agent therapy	CHEBI:24431	chemical entity	CHEBI:36047	antibacterial agent therapy					
 MAXO:0000062	antineoplastic agent therapy	CHEBI:24431	chemical entity	CHEBI:35610	antineoplastic agent					anti-neoplastic agent therapy
 MAXO:0000157	antiparkinson agent therapy	CHEBI:24431	chemical entity	CHEBI:48407	antiparkinson drug					anti-Parkinson agent therapy|treatment with anti-Parkinson drug

--- a/src/patterns/definitions.owl
+++ b/src/patterns/definitions.owl
@@ -7,8 +7,8 @@ Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
 
 
 Ontology(<http://purl.obolibrary.org/obo/maxo/patterns/definitions.owl>
-<http://purl.obolibrary.org/obo/maxo/releases/2022-12-09/patterns/definitions.owl>
-Annotation(owl:versionInfo "2022-12-09"^^xsd:string)
+<http://purl.obolibrary.org/obo/maxo/releases/2022-12-19/patterns/definitions.owl>
+Annotation(owl:versionInfo "2022-12-19"^^xsd:string)
 
 Declaration(Class(<http://purl.obolibrary.org/obo/CHEBI_12777>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CHEBI_132952>))
@@ -64,7 +64,6 @@ Declaration(Class(<http://purl.obolibrary.org/obo/CHEBI_22860>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CHEBI_22918>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CHEBI_22984>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CHEBI_23066>))
-Declaration(Class(<http://purl.obolibrary.org/obo/CHEBI_23888>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CHEBI_23924>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CHEBI_24020>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CHEBI_24261>))
@@ -1299,13 +1298,6 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynony
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/MAXO_0000048> "inflammation of the skin prevention recommendation"^^xsd:string)
 SubClassOf(<http://purl.obolibrary.org/obo/MAXO_0000048> <http://purl.obolibrary.org/obo/MAXO_0001113>)
 SubClassOf(<http://purl.obolibrary.org/obo/MAXO_0000048> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/MAXO_0000521> <http://purl.obolibrary.org/obo/HP_0011123>))
-
-# Class: <http://purl.obolibrary.org/obo/MAXO_0000058> (pharmacotherapy)
-
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/MAXO_0000058> "drug therapy"^^xsd:string)
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/MAXO_0000058> "treatment with drug"^^xsd:string)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/MAXO_0000058> "pharmacotherapy"^^xsd:string)
-EquivalentClasses(<http://purl.obolibrary.org/obo/MAXO_0000058> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/MAXO_0000058> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/MAXO_0000864> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/CHEBI_24431> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000087> <http://purl.obolibrary.org/obo/CHEBI_23888>)))))
 
 # Class: <http://purl.obolibrary.org/obo/MAXO_0000061> (antibacterial agent therapy)
 


### PR DESCRIPTION
pharmacotherapy term had a circular logical def as it was included in the pharmacotherapy pattern. Removed it from the pattern and added updated logical definition.