### PR TITLE
Feature/maxoa

### DIFF
--- a/src/ontology/maxo.Makefile
+++ b/src/ontology/maxo.Makefile
@@ -82,14 +82,10 @@ merge_template: $(MERGE_TEMPLATE)
 MAXOA_DIRECTORY=tmp/maxoa
 MAXOA_FILENAME=maxo-annotations.tsv
 maxoa:
-	# not log the line
-	# @test $(MAXOA_RELEASE_PASSWORD) || "ENV MAXOA_RELEASE_PASSWORD"
-	# @curl -f https://poet.jax.org/api/v1/export/release?key=$(MAXOA_RELEASE_PASSWORD) && echo "POET Release Success!" || echo "POET Release Failure"
-	# Get the MAXO annotation file
-	#echo $$(cat /etc/ssl/certs/ca-certificates.crt)
-	#curl -L http://purl.obolibrary.org/obo/hp/translations/hp-all.babelon.tsv
-	curl -Lk https://poet.jax.org/api/v1/export/maxo?unstable=false >> $(MAXOA_DIRECTORY)/$(MAXOA_FILENAME)
-    # Move or rename file with release date.
+	mkdir -p $(MAXOA_DIRECTORY)
+	@test $(MAXOA_RELEASE_PASSWORD) || "ENV MAXOA_RELEASE_PASSWORD"
+	@curl -Lk https://poet.jax.org/api/v1/export/release?key=$(MAXOA_RELEASE_PASSWORD) && echo "POET Release Success!" || echo "POET Release Failure."
+	@curl -Lk https://poet.jax.org/api/v1/export/maxo >> $(MAXOA_DIRECTORY)/$(MAXOA_FILENAME)
 
 #########################################
 ### Graveyard        ####################

--- a/src/ontology/maxo.Makefile
+++ b/src/ontology/maxo.Makefile
@@ -74,6 +74,23 @@ merge_template: $(MERGE_TEMPLATE)
  --template $(MERGE_TEMPLATE) convert -f ofn -o $(SRC)
 
 
+
+ #########################################
+### Get maxo annotations            ######
+##########################################
+# YOU MUST SET THE MAXOA_RELEASE_PASSWORD ENVRIONMENTAL VARIABLE WHEN RELEASING
+MAXOA_DIRECTORY=tmp/maxoa
+MAXOA_FILENAME=maxo-annotations.tsv
+maxoa:
+	# not log the line
+	# @test $(MAXOA_RELEASE_PASSWORD) || "ENV MAXOA_RELEASE_PASSWORD"
+	# @curl -f https://poet.jax.org/api/v1/export/release?key=$(MAXOA_RELEASE_PASSWORD) && echo "POET Release Success!" || echo "POET Release Failure"
+	# Get the MAXO annotation file
+	#echo $$(cat /etc/ssl/certs/ca-certificates.crt)
+	#curl -L http://purl.obolibrary.org/obo/hp/translations/hp-all.babelon.tsv
+	curl -Lk https://poet.jax.org/api/v1/export/maxo?unstable=false >> $(MAXOA_DIRECTORY)/$(MAXOA_FILENAME)
+    # Move or rename file with release date.
+
 #########################################
 ### Graveyard        ####################
 #########################################


### PR DESCRIPTION
This is the final piece for POET integration. You must set your ENV for maxoa key that I have, this will enable moving accepted annotations -> official annotations and the following line will export all official annotations in a tsv file.