### PR TITLE
Fix anti-viral issue

### DIFF
--- a/src/patterns/data/manual/pharmacotherapy_chemicalrole.tsv
+++ b/src/patterns/data/manual/pharmacotherapy_chemicalrole.tsv
@@ -45,7 +45,7 @@ MAXO:0000234	aromatase inhibitor agent therapy	CHEBI:24431	chemical entity	CHEBI
 MAXO:0000240	antiprotozoal agent therapy	CHEBI:24431	chemical entity	CHEBI:35820	antiprotozoal drug					
 MAXO:0000243	atypical antipsychotic agent therapy	CHEBI:24431	chemical entity	CHEBI:65191	second generation antipsychotic					
 MAXO:0000244	conventional antipsychotic agent therapy	CHEBI:24431	chemical entity	CHEBI:65190	first generation antipsychotic					
-MAXO:0000248	anti-HIV agent therapy	CHEBI:24431	chemical entity	CHEBI:22587	anti-HIV agent					
+MAXO:0000248	anti-HIV agent therapy	CHEBI:24431	chemical entity	CHEBI64946	anti-HIV agent					
 MAXO:0000249	"anti-HIV therapy, fusion inhibitor"	CHEBI:24431	chemical entity	CHEBI:59886	HIV fusion inhibitor					
 MAXO:0000252	HIV protease inhibitor therapy	CHEBI:24431	chemical entity	CHEBI:35660	HIV protease inhibitor					
 MAXO:0000256	antimanic agent therapy	CHEBI:24431	chemical entity	CHEBI:35477	antimanic drug					

--- a/src/patterns/data/manual/pharmacotherapy_chemicalrole.tsv
+++ b/src/patterns/data/manual/pharmacotherapy_chemicalrole.tsv
@@ -45,7 +45,7 @@ MAXO:0000234	aromatase inhibitor agent therapy	CHEBI:24431	chemical entity	CHEBI
 MAXO:0000240	antiprotozoal agent therapy	CHEBI:24431	chemical entity	CHEBI:35820	antiprotozoal drug					
 MAXO:0000243	atypical antipsychotic agent therapy	CHEBI:24431	chemical entity	CHEBI:65191	second generation antipsychotic					
 MAXO:0000244	conventional antipsychotic agent therapy	CHEBI:24431	chemical entity	CHEBI:65190	first generation antipsychotic					
-MAXO:0000248	anti-HIV agent therapy	CHEBI:24431	chemical entity	CHEBI64946	anti-HIV agent					
+MAXO:0000248	anti-HIV agent therapy	CHEBI:24431	chemical entity	CHEBI:64946	anti-HIV agent					
 MAXO:0000249	"anti-HIV therapy, fusion inhibitor"	CHEBI:24431	chemical entity	CHEBI:59886	HIV fusion inhibitor					
 MAXO:0000252	HIV protease inhibitor therapy	CHEBI:24431	chemical entity	CHEBI:35660	HIV protease inhibitor					
 MAXO:0000256	antimanic agent therapy	CHEBI:24431	chemical entity	CHEBI:35477	antimanic drug					

--- a/src/patterns/definitions.owl
+++ b/src/patterns/definitions.owl
@@ -247,6 +247,7 @@ Declaration(Class(<http://purl.obolibrary.org/obo/CHEBI_64102>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CHEBI_64133>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CHEBI_64571>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CHEBI_64912>))
+Declaration(Class(<http://purl.obolibrary.org/obo/CHEBI_64946>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CHEBI_64952>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CHEBI_64953>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CHEBI_64954>))
@@ -2105,7 +2106,7 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/MAXO_0000244> ObjectIntersecti
 
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/MAXO_0000248> "treatment with antiviral agent")
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/MAXO_0000248> "anti-HIV agent therapy")
-EquivalentClasses(<http://purl.obolibrary.org/obo/MAXO_0000248> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/MAXO_0000058> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/MAXO_0000864> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/CHEBI_24431> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000087> <http://purl.obolibrary.org/obo/CHEBI_22587>)))))
+EquivalentClasses(<http://purl.obolibrary.org/obo/MAXO_0000248> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/MAXO_0000058> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/MAXO_0000864> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/CHEBI_24431> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000087> <http://purl.obolibrary.org/obo/CHEBI_64946>)))))
 
 # Class: <http://purl.obolibrary.org/obo/MAXO_0000249> (anti-HIV therapy, fusion inhibitor)
 

--- a/src/patterns/definitions.owl
+++ b/src/patterns/definitions.owl
@@ -7,8 +7,8 @@ Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
 
 
 Ontology(<http://purl.obolibrary.org/obo/maxo/patterns/definitions.owl>
-<http://purl.obolibrary.org/obo/maxo/releases/2023-12-01/patterns/definitions.owl>
-Annotation(owl:versionInfo "2023-12-01")
+<http://purl.obolibrary.org/obo/maxo/releases/2024-02-01/patterns/definitions.owl>
+Annotation(owl:versionInfo "2024-02-01")
 
 Declaration(Class(<http://purl.obolibrary.org/obo/CHEBI_12777>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CHEBI_131795>))
@@ -63,7 +63,6 @@ Declaration(Class(<http://purl.obolibrary.org/obo/CHEBI_18248>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CHEBI_18257>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CHEBI_18405>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CHEBI_22333>))
-Declaration(Class(<http://purl.obolibrary.org/obo/CHEBI_22587>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CHEBI_22652>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CHEBI_22860>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CHEBI_22918>))
@@ -2104,7 +2103,7 @@ EquivalentClasses(<http://purl.obolibrary.org/obo/MAXO_0000244> ObjectIntersecti
 
 # Class: <http://purl.obolibrary.org/obo/MAXO_0000248> (anti-HIV agent therapy)
 
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/MAXO_0000248> "treatment with antiviral agent")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/MAXO_0000248> "treatment with anti-HIV agent")
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/MAXO_0000248> "anti-HIV agent therapy")
 EquivalentClasses(<http://purl.obolibrary.org/obo/MAXO_0000248> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/MAXO_0000058> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/MAXO_0000864> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/CHEBI_24431> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000087> <http://purl.obolibrary.org/obo/CHEBI_64946>)))))
 


### PR DESCRIPTION
There was a mistake in the Anti-HIV agent therapy pattern TSV where the wrong CHEBI ID was used. This fixes that issue that was causing false equivalency.